### PR TITLE
Implement a logarithmic fadeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,11 @@ IF(STDERR_DEBUGGING)
   add_compile_definitions(STDERR_DEBUGGING=1)
 ENDIF()
 
+OPTION (LOG_FADE "Use a logarithmic fadeout instead of a linear fadeout" ON)
+IF(LOG_FADE)
+  add_compile_definitions(LOG_FADE=1)
+ENDIF()
+
 # add include dir
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ IF(STDERR_DEBUGGING)
   add_compile_definitions(STDERR_DEBUGGING=1)
 ENDIF()
 
-OPTION (LOG_FADE "Use a logarithmic fadeout instead of a linear fadeout" ON)
+OPTION (LOG_FADE "Use a logarithmic fadeout instead of a linear fadeout" OFF)
 IF(LOG_FADE)
   add_compile_definitions(LOG_FADE=1)
 ENDIF()

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -41,11 +41,22 @@ inline int16_t linear_fade(const int16_t sample, const int64_t sample_n, const i
   return factor * sample;
 }
 
+// used for determining a factor that reduces the signal to
+// A*lower_threshold after fadeout_samples
 inline const double log_fade_factor(const int64_t fadeout_samples, const double lower_threshold) {
   // s'(n) = f**n * s(n)
   // want f such that for n=fadeout_samples, f**n = lower_threshold
   // f = lower_threshold**(1/n)
   return pow(lower_threshold, (double)1.0/(double)fadeout_samples);
+}
+
+// used for determining a factor that reduces the signal to A*factor
+// after fadeout_samples/2
+inline const double log_fade_half_factor(const int64_t fadeout_samples, const double factor) {
+  // s'(n) = f**n * s(n)
+  // want f such that for n=fadeout_samples/2, f**n = factor
+  // f = factor**(2/fadeout_samples)
+  return pow(factor, (double)2.0/(double)fadeout_samples);
 }
 
 inline int16_t log_fade(const int16_t sample, const int64_t sample_n,
@@ -74,7 +85,7 @@ inline size_t adjust_track_end(DB_functions_t *deadbeef, size_t to_copy, PluginS
     // fadeout must be applied to each channel separately
     int16_t* channel_samples = (int16_t*)state->output.sample_buffer.data();
     #ifdef LOG_FADE
-    const double fadeout_factor = log_fade_factor(state->fMetadata.FadeoutSamples, 0.01);
+    const double fadeout_factor = log_fade_half_factor(state->fMetadata.FadeoutSamples, 0.25);
     #endif
     // only apply the fadeout to the samples we will copy
     // other samples will be moved down the buffer and the fadeout

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -29,6 +29,7 @@ inline float total_length_seconds(const TrackMetadata &meta) {
   return (float)(meta.Length + meta.Fadeout) / 1000.0;
 }
 
+#ifndef LOG_FADE
 inline int16_t linear_fade(const int16_t sample, const int64_t sample_n, const int64_t fadeout_start, const int64_t fadeout_samples) {
   if (sample_n < fadeout_start)
     return sample;
@@ -40,7 +41,9 @@ inline int16_t linear_fade(const int16_t sample, const int64_t sample_n, const i
   double factor = 1 - m*x;
   return factor * sample;
 }
+#endif
 
+#ifdef LOG_FADE
 // used for determining a factor that reduces the signal to
 // A*lower_threshold after fadeout_samples
 inline const double log_fade_factor(const int64_t fadeout_samples, const double lower_threshold) {
@@ -69,6 +72,7 @@ inline int16_t log_fade(const int16_t sample, const int64_t sample_n,
   const double f = pow(fadeout_factor, n);
   return f * sample;
 }
+#endif
 
 inline size_t adjust_track_end(DB_functions_t *deadbeef, size_t to_copy, PluginState *state) {
   // if we would copy more samples than the length of the file, we


### PR DESCRIPTION
The logarithmic factor of this fade is currently chosen such that the amplitude of the sample at the midpoint of the fadeout is reduced by a factor of 0.25.

The log fadeout is currently not enabled by default, and users will have to build the project themselves with the cmake option `-DLOG_FADE=ON` in order to enable it. This is done for compatibility with previous versions, particularly as the linear fade works quite well as a general fade, whilst the logarithmic fade seems to work better for some tracks than it does for others. That said, it works fairly well as-is _so long as the track has correct ReplayGain information._

The plan is to eventually add a config menu for users to choose for themselves between the log fade and the linear fade without requiring a total recompile of the plugin. Ideally, the midpoint amplitude should be configurable from this menu as well.