### PR TITLE
Add configuration dialogue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,12 +26,6 @@ IF(STDERR_DEBUGGING)
   add_compile_definitions(STDERR_DEBUGGING=1)
 ENDIF()
 
-OPTION (LOG_FADE "Use a logarithmic fadeout instead of a linear fadeout" OFF)
-IF(LOG_FADE)
-  add_compile_definitions(LOG_FADE=1)
-  message("-- Logarithmic fadeout enabled")
-ENDIF()
-
 SET (DEFAULT_SAMPLE_RATE "44100" CACHE STRING "Set the default sample rate to be used for playback if not specified by the config")
 IF(DEFAULT_SAMPLE_RATE)
   add_compile_definitions(DEFAULTSAMPLERATE=${DEFAULT_SAMPLE_RATE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,13 @@ ENDIF()
 OPTION (LOG_FADE "Use a logarithmic fadeout instead of a linear fadeout" OFF)
 IF(LOG_FADE)
   add_compile_definitions(LOG_FADE=1)
+  message("-- Logarithmic fadeout enabled")
 ENDIF()
 
-SET (SAMPLE_RATE "44100" CACHE STRING "Set the sample rate to be used for playback")
-IF(SAMPLE_RATE)
-  add_compile_definitions(SAMPLERATE=${SAMPLE_RATE})
-  message("-- Sample rate set to ${SAMPLE_RATE}Hz")
+SET (DEFAULT_SAMPLE_RATE "44100" CACHE STRING "Set the default sample rate to be used for playback if not specified by the config")
+IF(DEFAULT_SAMPLE_RATE)
+  add_compile_definitions(DEFAULTSAMPLERATE=${DEFAULT_SAMPLE_RATE})
+  message("-- Default sample rate set to ${DEFAULT_SAMPLE_RATE}Hz")
 ENDIF()
 
 # add include dir

--- a/include/consts.h
+++ b/include/consts.h
@@ -1,13 +1,13 @@
 #ifndef GSF_CONSTS_H
 #define GSF_CONSTS_H 1
 
-#ifndef SAMPLERATE
-#define SAMPLERATE 44100
+#ifndef DEFAULTSAMPLERATE
+#define DEFAULTSAMPLERATE 44100
 #endif
 #ifdef __cplusplus
-constexpr int SAMPLE_RATE = SAMPLERATE;
+constexpr int DEFAULT_SAMPLE_RATE = DEFAULTSAMPLERATE;
 #else
-#define SAMPLE_RATE SAMPLERATE
+#define DEFAULT_SAMPLE_RATE DEFAULTSAMPLERATE
 #endif
 
 #endif

--- a/include/metadata.h
+++ b/include/metadata.h
@@ -10,9 +10,9 @@ struct TrackMetadata {
   ~TrackMetadata();
 
   double Length; // milliseconds
-  int64_t LengthSamples;
+  // int64_t LengthSamples;
   double Fadeout; // milliseconds
-  int64_t FadeoutSamples;
+  // int64_t FadeoutSamples;
   std::string Title;
   std::string Artist;
   std::string Year;

--- a/include/metadata.h
+++ b/include/metadata.h
@@ -9,6 +9,7 @@ struct TrackMetadata {
   TrackMetadata();
   ~TrackMetadata();
 
+  // TODO: maybe bring back the *Samples variables as an optimisation?
   double Length; // milliseconds
   // int64_t LengthSamples;
   double Fadeout; // milliseconds

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -34,6 +34,7 @@ struct PluginState {
   GSF_ROM ROM;
   uint32_t entry_point;
   bool set_entry;
+  bool use_log_fade;
   GBASystem fEmulator;
 };
 

--- a/src/load.c
+++ b/src/load.c
@@ -18,6 +18,10 @@ static int gsf_stop(void) { return 0; }
 
 static const char *exts[] = {"minigsf", NULL};
 
+static const char settings_dlg[] =
+  "property \"Sample rate\" entry gsf.samplerate " EXPAND(DEFAULTSAMPLERATE) ";\n"
+  ;
+
 static DB_decoder_t plugin = {
     DDB_REQUIRE_API_VERSION(1, 12)
  
@@ -43,14 +47,15 @@ static DB_decoder_t plugin = {
     #ifdef LOG_FADE
     " + LOG_FADE\n"
     #endif
-    #ifdef SAMPLERATE
-    " + SAMPLE_RATE: " EXPAND(SAMPLERATE)
+    #ifdef DEFAULTSAMPLERATE
+    " + DEFAULT_SAMPLE_RATE: " EXPAND(DEFAULTSAMPLERATE)
     #endif
     ,
     .plugin.website = "https://github.com/joshbarrass/deadbeef_GSFdecoder",
     .plugin.copyright = "Licensed under GPL v2",
     .plugin.start = gsf_start,
     .plugin.stop = gsf_stop,
+    .plugin.configdialog = settings_dlg,
     .plugin.flags = 0
     #ifdef ENABLE_LOGGING
     | DDB_PLUGIN_FLAG_LOGGING

--- a/src/load.c
+++ b/src/load.c
@@ -20,7 +20,7 @@ static const char *exts[] = {"minigsf", NULL};
 
 static const char settings_dlg[] =
   "property \"Sample rate\" entry gsf.samplerate " EXPAND(DEFAULTSAMPLERATE) ";\n"
-  "property \"Use logarithmic fadeout\" checkbox gsf.log_fade 1;\n"
+  "property \"Use logarithmic fadeout\" checkbox gsf.log_fade 1;\n" // this could be a dropdown in future to choose from different fadeout algorithms?
   ;
 
 static DB_decoder_t plugin = {

--- a/src/load.c
+++ b/src/load.c
@@ -20,6 +20,7 @@ static const char *exts[] = {"minigsf", NULL};
 
 static const char settings_dlg[] =
   "property \"Sample rate\" entry gsf.samplerate " EXPAND(DEFAULTSAMPLERATE) ";\n"
+  "property \"Use logarithmic fadeout\" checkbox gsf.log_fade 1;\n"
   ;
 
 static DB_decoder_t plugin = {

--- a/src/load.c
+++ b/src/load.c
@@ -45,9 +45,6 @@ static DB_decoder_t plugin = {
     #ifdef STDERR_DEBUGGING
     " + STDERR_DEBUGGING\n"
     #endif
-    #ifdef LOG_FADE
-    " + LOG_FADE\n"
-    #endif
     #ifdef DEFAULTSAMPLERATE
     " + DEFAULT_SAMPLE_RATE: " EXPAND(DEFAULTSAMPLERATE)
     #endif

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -3,7 +3,7 @@
 #include "psflib.h"
 
 TrackMetadata::TrackMetadata()
-  : Length(0), LengthSamples(0), Fadeout(0), FadeoutSamples(0), Title(""), Artist(""), Year(""), Game(""), Comment(""), set_RG_album(false), RG_AGAIN(0), RG_APEAK(1), set_RG_track(false), RG_TGAIN(0), RG_TPEAK(1) {
+  : Length(0), Fadeout(0), Title(""), Artist(""), Year(""), Game(""), Comment(""), set_RG_album(false), RG_AGAIN(0), RG_APEAK(1), set_RG_track(false), RG_TGAIN(0), RG_TPEAK(1) {
   // explicitly clear the map to avoid any issues with reused memory
   OtherMeta.clear();
 }

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -22,8 +22,12 @@ inline PluginState *get_plugin_state(DB_fileinfo_t *_info) {
   return (PluginState*)_info;
 }
 
-inline int64_t total_length_samples(const TrackMetadata &meta) {
-  return meta.LengthSamples + meta.FadeoutSamples;
+inline int64_t length_to_samples(double length_ms, int64_t sample_rate) {
+  return sample_rate * length_ms / 1000;
+}
+
+inline int64_t total_length_samples(const TrackMetadata &meta, int64_t sample_rate) {
+  return length_to_samples(meta.Length, sample_rate) + length_to_samples(meta.Fadeout, sample_rate);
 }
 
 inline float total_length_seconds(const TrackMetadata &meta) {
@@ -76,37 +80,39 @@ inline int16_t log_fade(const int16_t sample, const int64_t sample_n,
 #endif
 
 inline size_t adjust_track_end(DB_functions_t *deadbeef, size_t to_copy, PluginState *state) {
+  int sample_rate = state->fFileInfo.fmt.samplerate;
   // if we would copy more samples than the length of the file, we
   // need to trim the buffer, but ONLY if we aren't looping!
   bool should_loop = (deadbeef->streamer_get_repeat () == DDB_REPEAT_SINGLE) && (state->hints & DDB_DECODER_HINT_CAN_LOOP);
   if (!should_loop) {
-    size_t remaining_samples = total_length_samples(state->fMetadata) - state->readsample;
+    size_t remaining_samples = total_length_samples(state->fMetadata, sample_rate) - state->readsample;
     if (to_copy > remaining_samples)
       to_copy = remaining_samples;
 
-    const int64_t fadeout_start = state->fMetadata.LengthSamples;
+    const int64_t fadeout_start = length_to_samples(state->fMetadata.Length, sample_rate);
     const int64_t readsample = state->readsample;
     // each sample is 4 bytes with 2 bytes per channel
     // fadeout must be applied to each channel separately
     int16_t* channel_samples = (int16_t*)state->output.sample_buffer.data();
     #ifdef LOG_FADE
-    const double fadeout_factor = log_fade_half_factor(state->fMetadata.FadeoutSamples, 0.25);
+    const double fadeout_factor = log_fade_half_factor(
+                                                       length_to_samples(state->fMetadata.Fadeout, sample_rate),
+                                                       0.25);
     #endif
     // only apply the fadeout to the samples we will copy
     // other samples will be moved down the buffer and the fadeout
     // will be applied to those later if needed
-    for (int i = 0; i < to_copy/2; ++i) {
-      #ifdef LOG_FADE
-      channel_samples[i] = log_fade(channel_samples[i],
-                                       readsample+i,
-                                       fadeout_start,
-                                       fadeout_factor);
-      #else
-      channel_samples[i] = linear_fade(channel_samples[i],
-                                       readsample + i,
-                                       fadeout_start,
-                                       state->fMetadata.FadeoutSamples);
-      #endif
+    if (state->fMetadata.Fadeout > 0) {
+      for (int i = 0; i < to_copy / 2; ++i) { // div 2 here as we process one channel (2 bytes) at a time
+#ifdef LOG_FADE
+        channel_samples[i] = log_fade(channel_samples[i], readsample + (int)(i),
+                                      fadeout_start, fadeout_factor);
+#else
+        channel_samples[i] = linear_fade(
+            channel_samples[i], readsample + i, fadeout_start,
+            length_to_samples(state->fMetadata.Fadeout, sample_rate));
+#endif
+      }
     }
   }
 
@@ -147,9 +153,11 @@ int gsf_init(DB_fileinfo_t *info, DB_playItem_t *it) {
   }
   #endif
 
+  int config_sample_rate = deadbeef->conf_get_int ("gsf.samplerate", DEFAULT_SAMPLE_RATE);
+
   info->fmt.bps = 16;
   info->fmt.channels = 2;
-  info->fmt.samplerate = deadbeef->conf_get_int ("synth.samplerate", SAMPLE_RATE);
+  info->fmt.samplerate = config_sample_rate;
   info->fmt.channelmask = info->fmt.channels == 1 ? DDB_SPEAKER_FRONT_LEFT : (DDB_SPEAKER_FRONT_LEFT | DDB_SPEAKER_FRONT_RIGHT);
   info->readpos = 0;
   info->plugin = plugin;
@@ -186,7 +194,7 @@ int gsf_init(DB_fileinfo_t *info, DB_playItem_t *it) {
     return -3;
   }
   soundInit(&state->fEmulator, &state->output);
-  soundSetSampleRate(&state->fEmulator, SAMPLE_RATE);
+  soundSetSampleRate(&state->fEmulator, info->fmt.samplerate);
   soundReset(&state->fEmulator);
   CPUInit(&state->fEmulator);
   CPUReset(&state->fEmulator);
@@ -220,6 +228,7 @@ int gsf_read(DB_fileinfo_t *_info, char *buffer, int nbytes) {
   auto deadbeef = get_API_pointer();
   auto plugin = get_plugin_pointer();
   PluginState *state = get_plugin_state(_info);
+  int sample_rate = _info->fmt.samplerate;
 
   if (!state->fInit) {
     trace("GSF ERR: attempt to read from uninitialised plugin state\n");
@@ -234,7 +243,7 @@ int gsf_read(DB_fileinfo_t *_info, char *buffer, int nbytes) {
   #endif
   bool should_loop = (deadbeef->streamer_get_repeat () == DDB_REPEAT_SINGLE) && (state->hints & DDB_DECODER_HINT_CAN_LOOP);
   if (!should_loop) {
-    if (state->readsample >= total_length_samples(state->fMetadata)) {
+    if (state->readsample >= total_length_samples(state->fMetadata, sample_rate)) {
 #ifdef BUILD_DEBUG
       tracedbg("GSF DEBUG: end of track\n");
 #endif
@@ -295,13 +304,13 @@ int gsf_read(DB_fileinfo_t *_info, char *buffer, int nbytes) {
   // 16-bit samples, stereo, so 4 bytes per sample
   // SAMPLE_RATE samples per second
   state->readsample += to_copy / 4;
-  _info->readpos += (float)to_copy / SAMPLE_RATE / 4;
+  _info->readpos += (float)to_copy / _info->fmt.samplerate / 4;
 
   return to_copy;
 }
 
 int gsf_seek(DB_fileinfo_t *info, float seconds) {
-  int sample = seconds * SAMPLE_RATE;
+  int sample = seconds * info->fmt.samplerate;
   return gsf_seek_sample(info, sample);
 }
 
@@ -362,7 +371,7 @@ int gsf_seek_sample(DB_fileinfo_t *info, int sample) {
       CPULoop(&state->fEmulator, 250000);
     }
   }
-  info->readpos = (double)state->readsample / (double)SAMPLE_RATE;
+  info->readpos = (double)state->readsample / (double)info->fmt.samplerate;
   return 0;
 }
 

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -85,9 +85,12 @@ inline size_t adjust_track_end(DB_functions_t *deadbeef, size_t to_copy, PluginS
   // need to trim the buffer, but ONLY if we aren't looping!
   bool should_loop = (deadbeef->streamer_get_repeat () == DDB_REPEAT_SINGLE) && (state->hints & DDB_DECODER_HINT_CAN_LOOP);
   if (!should_loop) {
-    size_t remaining_samples = total_length_samples(state->fMetadata, sample_rate) - state->readsample;
-    if (to_copy > remaining_samples)
-      to_copy = remaining_samples;
+    int64_t remaining_samples = total_length_samples(state->fMetadata, sample_rate) - state->readsample;
+    // one sample is 4 bytes (16-bit per channel, 2 channels), so we
+    // must convert remaining_samples into bytes and use this value.
+    size_t remaining_bytes = remaining_samples * 4;
+    if (to_copy > remaining_bytes)
+      to_copy = remaining_bytes;
 
     const int64_t fadeout_start = length_to_samples(state->fMetadata.Length, sample_rate);
     const int64_t readsample = state->readsample;

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -165,6 +165,9 @@ int gsf_init(DB_fileinfo_t *info, DB_playItem_t *it) {
   info->readpos = 0;
   info->plugin = plugin;
 
+  // add sample rate information to the status bar
+  deadbeef->pl_set_meta_int(it, ":SAMPLERATE", info->fmt.samplerate);
+
   deadbeef->pl_lock ();
   std::string uri(deadbeef->pl_find_meta (it, ":URI"));
   deadbeef->pl_unlock ();

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -9,7 +9,7 @@
 // plugin state will often occupy the same memory as a previous state,
 // must be careful to ensure everything is properly initialised to
 // avoid segfaults
-PluginState::PluginState() : fFileInfo(), readsample(0), fInit(false), hints(0), fMetadata(), output(), ROM(), entry_point(0), set_entry(false), fEmulator() {}
+PluginState::PluginState() : fFileInfo(), readsample(0), fInit(false), hints(0), fMetadata(), output(), ROM(), entry_point(0), set_entry(false), use_log_fade(false), fEmulator() {}
 
 PluginState::~PluginState() {
   if (fInit) {

--- a/src/psflib.cpp
+++ b/src/psflib.cpp
@@ -172,10 +172,10 @@ int gsf_info_callback(void *context, const char *name, const char *value) {
     return 0;
   else if (!strcasecmp(name, "length")) {
     meta->Length = parse_time(value); // milliseconds
-    meta->LengthSamples = SAMPLE_RATE * meta->Length / 1000;
+    // meta->LengthSamples = SAMPLE_RATE * meta->Length / 1000;
   } else if (!strcasecmp(name, "fade")) {
     meta->Fadeout = parse_time(value); // milliseconds
-    meta->FadeoutSamples = SAMPLE_RATE * meta->Fadeout / 1000;
+    // meta->FadeoutSamples = SAMPLE_RATE * meta->Fadeout / 1000;
   } else if (!strcasecmp(name, "title"))
     meta->Title = value;
   else if (!strcasecmp(name, "artist"))


### PR DESCRIPTION
This PR aims to add a configuration dialogue to allow editing various settings that are currently set at compile-time via arguments to CMake.

### Settings added

- [x] Sample rate
- [x] Toggle for logarithmic fadeout (instead of linear)
- ~~[ ] Toggle for debug logs (maybe)~~

### Other changes

 - Fixes #24 (a10f4a1054d810fbfd71c5a14807432b29350e14)
 - Display the sample rate on the status bar (06f7fec0035a8272fd679fef83a4029115f40a70)

### TODO

 - [x] Clean up duplicate calls to `length_to_samples` and `total_length_samples`