### PR TITLE
Standardising various variable types

### DIFF
--- a/include/plugin.h
+++ b/include/plugin.h
@@ -27,7 +27,7 @@ struct PluginState {
   ~PluginState();
 
   DB_fileinfo_t fFileInfo;
-  sample_t readsample;
+  sample_count_t readsample;
   bool fInit;
   uint32_t hints;
   TrackMetadata fMetadata;

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -26,7 +26,7 @@ struct PluginState {
   ~PluginState();
 
   DB_fileinfo_t fFileInfo;
-  int readsample;
+  long readsample;
   bool fInit;
   uint32_t hints;
   TrackMetadata fMetadata;

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -2,6 +2,7 @@
 #define GSF_PLUGIN_H 1
 
 #include "deadbeef/deadbeef.h"
+#include "types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,7 +27,7 @@ struct PluginState {
   ~PluginState();
 
   DB_fileinfo_t fFileInfo;
-  long readsample;
+  sample_t readsample;
   bool fInit;
   uint32_t hints;
   TrackMetadata fMetadata;

--- a/include/rom.h
+++ b/include/rom.h
@@ -11,7 +11,7 @@ public:
   int GetSize() const { return fData.size(); }
   uint8_t *GetArray() { return fData.data(); }
 
-  int WriteBytes(const uint8_t *, const unsigned int, const unsigned int);
+  int WriteBytes(const uint8_t *, const size_t, const size_t);
 
 private:
   std::vector<uint8_t> fData;

--- a/include/types.h
+++ b/include/types.h
@@ -1,6 +1,19 @@
 #ifndef GSF_TYPES_H
 #define GSF_TYPES_H 1
 
+#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
+// sample_count_t represents a number of samples
+// used for e.g. tracking the current sample
+// also used for samples rates (since this is #samples / second)
 typedef long sample_count_t;
+
+// sample_t represents a single audio sample (one channel)
+// we are using signed 16-bit audio, so 1 sample = 16 bits
+typedef int16_t sample_t;
 
 #endif

--- a/include/types.h
+++ b/include/types.h
@@ -1,0 +1,6 @@
+#ifndef GSF_TYPES_H
+#define GSF_TYPES_H 1
+
+typedef long sample_t;
+
+#endif

--- a/include/types.h
+++ b/include/types.h
@@ -1,6 +1,6 @@
 #ifndef GSF_TYPES_H
 #define GSF_TYPES_H 1
 
-typedef long sample_t;
+typedef long sample_count_t;
 
 #endif

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -34,7 +34,7 @@ inline constexpr sample_count_t total_length_seconds(const TrackMetadata &meta) 
   return (float)(meta.Length + meta.Fadeout) / 1000.0;
 }
 
-inline constexpr int16_t linear_fade(const int16_t sample, const sample_count_t sample_n, const sample_count_t fadeout_start, const sample_count_t fadeout_samples) {
+inline constexpr sample_t linear_fade(const sample_t sample, const sample_count_t sample_n, const sample_count_t fadeout_start, const sample_count_t fadeout_samples) {
   if (sample_n < fadeout_start)
     return sample;
 
@@ -64,7 +64,7 @@ inline const double log_fade_half_factor(const sample_count_t fadeout_samples, c
   return pow(factor, (double)2.0/(double)fadeout_samples);
 }
 
-inline int16_t log_fade(const int16_t sample, const sample_count_t sample_n,
+inline sample_t log_fade(const sample_t sample, const sample_count_t sample_n,
                         const sample_count_t fadeout_start,
                         const double fadeout_factor) {
   if (sample_n < fadeout_start)
@@ -97,7 +97,7 @@ inline size_t adjust_track_end(DB_functions_t *deadbeef, size_t to_copy, PluginS
     const sample_count_t fadeout_start = length_samples;
     // each sample is 4 bytes with 2 bytes per channel
     // fadeout must be applied to each channel separately
-    int16_t* channel_samples = (int16_t*)state->output.sample_buffer.data();
+    sample_t* channel_samples = (sample_t*)state->output.sample_buffer.data();
     double fadeout_factor;
     if (use_log_fade) {
       fadeout_factor = log_fade_half_factor(fadeout_samples, 0.25);

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -22,25 +22,25 @@ inline PluginState *get_plugin_state(DB_fileinfo_t *_info) {
   return (PluginState*)_info;
 }
 
-inline constexpr sample_t length_to_samples(const double length_ms, const sample_t sample_rate) {
+inline constexpr sample_count_t length_to_samples(const double length_ms, const sample_count_t sample_rate) {
   return sample_rate * length_ms / 1000;
 }
 
-inline constexpr sample_t total_length_samples(const TrackMetadata &meta, const sample_t sample_rate) {
+inline constexpr sample_count_t total_length_samples(const TrackMetadata &meta, const sample_count_t sample_rate) {
   return length_to_samples(meta.Length, sample_rate) + length_to_samples(meta.Fadeout, sample_rate);
 }
 
-inline constexpr sample_t total_length_seconds(const TrackMetadata &meta) {
+inline constexpr sample_count_t total_length_seconds(const TrackMetadata &meta) {
   return (float)(meta.Length + meta.Fadeout) / 1000.0;
 }
 
-inline constexpr int16_t linear_fade(const int16_t sample, const sample_t sample_n, const sample_t fadeout_start, const sample_t fadeout_samples) {
+inline constexpr int16_t linear_fade(const int16_t sample, const sample_count_t sample_n, const sample_count_t fadeout_start, const sample_count_t fadeout_samples) {
   if (sample_n < fadeout_start)
     return sample;
 
   // don't worry about x > fadeout_samples; this should never happen
   // as any earlier checks will end the track before then
-  const sample_t x = sample_n - fadeout_start;
+  const sample_count_t x = sample_n - fadeout_start;
   const double m = 1.0 / (double)(fadeout_samples);
   double factor = 1 - m*x;
   return factor * sample;
@@ -48,7 +48,7 @@ inline constexpr int16_t linear_fade(const int16_t sample, const sample_t sample
 
 // used for determining a factor that reduces the signal to
 // A*lower_threshold after fadeout_samples
-inline const double log_fade_factor(const sample_t fadeout_samples, const double lower_threshold) {
+inline const double log_fade_factor(const sample_count_t fadeout_samples, const double lower_threshold) {
   // s'(n) = f**n * s(n)
   // want f such that for n=fadeout_samples, f**n = lower_threshold
   // f = lower_threshold**(1/n)
@@ -57,44 +57,44 @@ inline const double log_fade_factor(const sample_t fadeout_samples, const double
 
 // used for determining a factor that reduces the signal to A*factor
 // after fadeout_samples/2
-inline const double log_fade_half_factor(const sample_t fadeout_samples, const double factor) {
+inline const double log_fade_half_factor(const sample_count_t fadeout_samples, const double factor) {
   // s'(n) = f**n * s(n)
   // want f such that for n=fadeout_samples/2, f**n = factor
   // f = factor**(2/fadeout_samples)
   return pow(factor, (double)2.0/(double)fadeout_samples);
 }
 
-inline int16_t log_fade(const int16_t sample, const sample_t sample_n,
-                        const sample_t fadeout_start,
+inline int16_t log_fade(const int16_t sample, const sample_count_t sample_n,
+                        const sample_count_t fadeout_start,
                         const double fadeout_factor) {
   if (sample_n < fadeout_start)
     return sample;
 
-  const sample_t n = sample_n - fadeout_start;
+  const sample_count_t n = sample_n - fadeout_start;
   const double f = pow(fadeout_factor, (double)n);
   return f * sample;
 }
 
 inline size_t adjust_track_end(DB_functions_t *deadbeef, size_t to_copy, PluginState *state) {
-  const sample_t sample_rate = state->fFileInfo.fmt.samplerate;
+  const sample_count_t sample_rate = state->fFileInfo.fmt.samplerate;
   // if we would copy more samples than the length of the file, we
   // need to trim the buffer, but ONLY if we aren't looping!
   const bool should_loop = (deadbeef->streamer_get_repeat () == DDB_REPEAT_SINGLE) && (state->hints & DDB_DECODER_HINT_CAN_LOOP);
   const bool use_log_fade = state->use_log_fade;
   if (!should_loop) {
-    const sample_t total_samples = total_length_samples(state->fMetadata, sample_rate);
-    const sample_t length_samples = length_to_samples(state->fMetadata.Length, sample_rate);
-    const sample_t fadeout_samples = length_to_samples(state->fMetadata.Fadeout, sample_rate);
+    const sample_count_t total_samples = total_length_samples(state->fMetadata, sample_rate);
+    const sample_count_t length_samples = length_to_samples(state->fMetadata.Length, sample_rate);
+    const sample_count_t fadeout_samples = length_to_samples(state->fMetadata.Fadeout, sample_rate);
 
-    const sample_t readsample = state->readsample;
-    const sample_t remaining_samples = total_samples - readsample;
+    const sample_count_t readsample = state->readsample;
+    const sample_count_t remaining_samples = total_samples - readsample;
     // one sample is 4 bytes (16-bit per channel, 2 channels), so we
     // must convert remaining_samples into bytes and use this value.
     const size_t remaining_bytes = remaining_samples * 4;
     if (to_copy > remaining_bytes)
       to_copy = remaining_bytes;
 
-    const sample_t fadeout_start = length_samples;
+    const sample_count_t fadeout_start = length_samples;
     // each sample is 4 bytes with 2 bytes per channel
     // fadeout must be applied to each channel separately
     int16_t* channel_samples = (int16_t*)state->output.sample_buffer.data();
@@ -154,7 +154,7 @@ int gsf_init(DB_fileinfo_t *info, DB_playItem_t *it) {
   }
   #endif
 
-  sample_t config_sample_rate = deadbeef->conf_get_int64 ("gsf.samplerate", DEFAULT_SAMPLE_RATE);
+  sample_count_t config_sample_rate = deadbeef->conf_get_int64 ("gsf.samplerate", DEFAULT_SAMPLE_RATE);
   state->use_log_fade = deadbeef->conf_get_int("gsf.log_fade", 1);
 
   info->fmt.bps = 16;
@@ -233,7 +233,7 @@ int gsf_read(DB_fileinfo_t *_info, char *buffer, int nbytes) {
   auto deadbeef = get_API_pointer();
   auto plugin = get_plugin_pointer();
   PluginState *state = get_plugin_state(_info);
-  const sample_t sample_rate = _info->fmt.samplerate;
+  const sample_count_t sample_rate = _info->fmt.samplerate;
 
   if (!state->fInit) {
     trace("GSF ERR: attempt to read from uninitialised plugin state\n");
@@ -315,7 +315,7 @@ int gsf_read(DB_fileinfo_t *_info, char *buffer, int nbytes) {
 }
 
 int gsf_seek(DB_fileinfo_t *info, float seconds) {
-  sample_t sample = seconds * info->fmt.samplerate;
+  sample_count_t sample = seconds * info->fmt.samplerate;
   return gsf_seek_sample(info, sample);
 }
 
@@ -331,7 +331,7 @@ int gsf_seek_sample(DB_fileinfo_t *info, int sample) {
     state->readsample = 0;
   }
 
-  sample_t to_seek = sample - state->readsample;
+  sample_count_t to_seek = sample - state->readsample;
   size_t &in_buffer = state->output.bytes_in_buffer;
   while (to_seek > 0) {
     #ifdef BUILD_DEBUG
@@ -343,7 +343,7 @@ int gsf_seek_sample(DB_fileinfo_t *info, int sample) {
     #endif
     #endif
     if (in_buffer > 0) {
-      sample_t samples_in_buffer = in_buffer / 4;
+      sample_count_t samples_in_buffer = in_buffer / 4;
       if (samples_in_buffer <= to_seek) {
         #ifdef BUILD_DEBUG
         tracedbg("GSF DEBUG: Discarding buffer\n");

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -22,19 +22,19 @@ inline PluginState *get_plugin_state(DB_fileinfo_t *_info) {
   return (PluginState*)_info;
 }
 
-inline long length_to_samples(double length_ms, long sample_rate) {
+inline constexpr long length_to_samples(const double length_ms, const long sample_rate) {
   return sample_rate * length_ms / 1000;
 }
 
-inline long total_length_samples(const TrackMetadata &meta, long sample_rate) {
+inline constexpr long total_length_samples(const TrackMetadata &meta, const long sample_rate) {
   return length_to_samples(meta.Length, sample_rate) + length_to_samples(meta.Fadeout, sample_rate);
 }
 
-inline long total_length_seconds(const TrackMetadata &meta) {
+inline constexpr long total_length_seconds(const TrackMetadata &meta) {
   return (float)(meta.Length + meta.Fadeout) / 1000.0;
 }
 
-inline int16_t linear_fade(const int16_t sample, const long sample_n, const long fadeout_start, const long fadeout_samples) {
+inline constexpr int16_t linear_fade(const int16_t sample, const long sample_n, const long fadeout_start, const long fadeout_samples) {
   if (sample_n < fadeout_start)
     return sample;
 

--- a/src/play.cpp
+++ b/src/play.cpp
@@ -30,8 +30,8 @@ inline constexpr sample_count_t total_length_samples(const TrackMetadata &meta, 
   return length_to_samples(meta.Length, sample_rate) + length_to_samples(meta.Fadeout, sample_rate);
 }
 
-inline constexpr sample_count_t total_length_seconds(const TrackMetadata &meta) {
-  return (float)(meta.Length + meta.Fadeout) / 1000.0;
+inline constexpr double total_length_seconds(const TrackMetadata &meta) {
+  return (meta.Length + meta.Fadeout) / 1000.0;
 }
 
 inline constexpr sample_t linear_fade(const sample_t sample, const sample_count_t sample_n, const sample_count_t fadeout_start, const sample_count_t fadeout_samples) {

--- a/src/rom.cpp
+++ b/src/rom.cpp
@@ -9,9 +9,9 @@ GSF_ROM::~GSF_ROM() {}
 // given offset location. Bounds checking will be performed to ensure
 // the internal data structure is of a sufficient size to store the
 // data
-int GSF_ROM::WriteBytes(const uint8_t *data, const unsigned int n, const unsigned int offset) {
+int GSF_ROM::WriteBytes(const uint8_t *data, const size_t n, const size_t offset) {
   // ensure vector is sufficiently large
-  unsigned int required_size = offset + n;
+  size_t required_size = offset + n;
   if (fData.size() < required_size) {
     fData.resize(required_size, 0);
   }


### PR DESCRIPTION
Define two type aliases: `sample_count_t`, which represents a number of samples (and also sample rates, since these are technically # samples / second); and `sample_t`, which represents a single mono sample of audio data. These clarify a little more in the code itself what various variables represent, make it easier to standardise the type across different functions, and allow the type to be changed more easily if desired for whatever reason.

Sample counts are standardised to use `long`. The C++ standard should guarantee we can store up to at least 2147483647, which should be sufficient for almost all audio files at most sample rates. As a back of the napkin calculation, 2147483647 samples @ 44100Hz is 13.5hrs, and 2147483647 samples @ 220500Hz (which should be complete overkill here!) is 2.7hrs. These are far longer than any individual GSF I've encountered, and would allow an extremely long loop before any overflow effects would be encountered. In reality, GCC tends to use 8-bit `long`s, which has a maximum of 9223372036854775807, leading to maximum sample numbers corresponding to millions of years of continuous playback. I suspect this will be more than long enough (:

Samples, as we are using 16-bit audio, are simply `int16_t`. The type alias is more for clarity than any other reason.

I'll use this in a local build for a while to make sure nothing is obviously broken, then I can look at merging this.

Closes #26.